### PR TITLE
Use ordinal instead of additional DLL (note: only works in .NET)

### DIFF
--- a/XInputDemo/Program.cs
+++ b/XInputDemo/Program.cs
@@ -14,7 +14,7 @@ namespace XInputDemo
                 Console.WriteLine("IsConnected {0} Packet #{1}", state.IsConnected, state.PacketNumber);
                 Console.WriteLine("\tTriggers {0} {1}", state.Triggers.Left, state.Triggers.Right);
                 Console.WriteLine("\tD-Pad {0} {1} {2} {3}", state.DPad.Up, state.DPad.Right, state.DPad.Down, state.DPad.Left);
-                Console.WriteLine("\tButtons Start {0} Back {1} LeftStick {2} RightStick {3} LeftShoulder {4} RightShoulder {5} Guide {6} A {7} B {9} X {9} Y {10}",
+                Console.WriteLine("\tButtons Start {0} Back {1} LeftStick {2} RightStick {3} LeftShoulder {4} RightShoulder {5} Guide {6} A {7} B {8} X {9} Y {10}",
                     state.Buttons.Start, state.Buttons.Back, state.Buttons.LeftStick, state.Buttons.RightStick, state.Buttons.LeftShoulder, state.Buttons.RightShoulder,
                     state.Buttons.Guide, state.Buttons.A, state.Buttons.B, state.Buttons.X, state.Buttons.Y);
                 Console.WriteLine("\tSticks Left {0} {1} Right {2} {3}", state.ThumbSticks.Left.X, state.ThumbSticks.Left.Y, state.ThumbSticks.Right.X, state.ThumbSticks.Right.Y);

--- a/XInputDotNetPure/GamePad.cs
+++ b/XInputDotNetPure/GamePad.cs
@@ -5,12 +5,12 @@ namespace XInputDotNetPure
 {
     class Imports
     {
-        internal const string DLLName = "XInputInterface";
+        internal const string DLLName = "xinput1_3";
 
+        [DllImport(DLLName, EntryPoint = "#100")]
+        public static extern uint XInputGetStateEx(uint playerIndex, out GamePadState.RawState state);
         [DllImport(DLLName)]
-        public static extern uint XInputGamePadGetState(uint playerIndex, out GamePadState.RawState state);
-        [DllImport(DLLName)]
-        public static extern void XInputGamePadSetState(uint playerIndex, float leftMotor, float rightMotor);
+        public static extern uint XInputSetState(uint playerIndex, ref XInputVibrationState vib);
     }
 
     public enum ButtonState
@@ -343,13 +343,23 @@ namespace XInputDotNetPure
         public static GamePadState GetState(PlayerIndex playerIndex, GamePadDeadZone deadZone)
         {
             GamePadState.RawState state;
-            uint result = Imports.XInputGamePadGetState((uint)playerIndex, out state);
+            uint result = Imports.XInputGetStateEx((uint)playerIndex, out state);
             return new GamePadState(result == Utils.Success, state, deadZone);
         }
 
         public static void SetVibration(PlayerIndex playerIndex, float leftMotor, float rightMotor)
         {
-            Imports.XInputGamePadSetState((uint)playerIndex, leftMotor, rightMotor);
+            XInputVibrationState vib = new XInputVibrationState();
+            vib.LeftMotorSpeed = (ushort)(leftMotor * 65535);
+            vib.RightMotorSpeed = (ushort)(rightMotor * 65535);
+            Imports.XInputSetState((uint)playerIndex, ref vib);
         }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct XInputVibrationState
+    {
+        public ushort LeftMotorSpeed;
+        public ushort RightMotorSpeed;
     }
 }


### PR DESCRIPTION
Hello speps.
I tried importing xinput1_3.dll directly on XInputDotNetPure.

I confirmed it works on XInputDemo.exe and XInputReporter.exe including Guide Button but I don't use Unity, it's not tested on XInputUnity.
Because I can't judged whether XInputUnity needs XInputInterface, it's remained.

I also found an adjusting point on XInputDemo.exe.

P.S. I'm sorry for my strange English.
