### PR TITLE
Check for XInput 1.4 and 9.1.0 when 1.3 is missing

### DIFF
--- a/XInputDemo/Program.cs
+++ b/XInputDemo/Program.cs
@@ -14,7 +14,7 @@ namespace XInputDemo
                 Console.WriteLine("IsConnected {0} Packet #{1}", state.IsConnected, state.PacketNumber);
                 Console.WriteLine("\tTriggers {0} {1}", state.Triggers.Left, state.Triggers.Right);
                 Console.WriteLine("\tD-Pad {0} {1} {2} {3}", state.DPad.Up, state.DPad.Right, state.DPad.Down, state.DPad.Left);
-                Console.WriteLine("\tButtons Start {0} Back {1} LeftStick {2} RightStick {3} LeftShoulder {4} RightShoulder {5} Guide {6} A {7} B {9} X {9} Y {10}",
+                Console.WriteLine("\tButtons Start {0} Back {1} LeftStick {2} RightStick {3} LeftShoulder {4} RightShoulder {5} Guide {6} A {7} B {8} X {9} Y {10}",
                     state.Buttons.Start, state.Buttons.Back, state.Buttons.LeftStick, state.Buttons.RightStick, state.Buttons.LeftShoulder, state.Buttons.RightShoulder,
                     state.Buttons.Guide, state.Buttons.A, state.Buttons.B, state.Buttons.X, state.Buttons.Y);
                 Console.WriteLine("\tSticks Left {0} {1} Right {2} {3}", state.ThumbSticks.Left.X, state.ThumbSticks.Left.Y, state.ThumbSticks.Right.X, state.ThumbSticks.Right.Y);

--- a/XInputInterface/GamePad.cpp
+++ b/XInputInterface/GamePad.cpp
@@ -22,7 +22,29 @@ namespace
 		{
 			if (!mLoaded)
 			{
+				// Keep hold of error codes from each library we try to load.
+				DWORD xinput1_3_ErrorCode = 0;
+				DWORD xinput1_4_ErrorCode = 0;
+				DWORD xinput9_1_ErrorCode = 0;
+
+				// Try XInput 1.3 first as it has all the features we need.
 				mHandle = LoadLibrary("xinput1_3.dll");
+				xinput1_3_ErrorCode = GetLastError();
+
+				// Look for XInput 1.4 as a backup (newer machines may not have 1.3 at all).
+				if(mHandle == NULL)
+				{
+					mHandle = LoadLibrary("xinput1_4.dll");
+					xinput1_4_ErrorCode = GetLastError();
+				}
+
+				// Look for XInput 9.1.0 as a last resort! One of the others should exist but we may as well try to load it.
+				if(mHandle == NULL)
+				{
+					mHandle = LoadLibrary("xinput9_1_0.dll");
+					xinput9_1_ErrorCode = GetLastError();
+				}
+
 				if (mHandle != NULL)
 				{
 					mGetState = (XInputGetStatePointer)GetProcAddress(mHandle, (LPCSTR)100); // Ordinal 100 is the same as XInputGetState but supports the Guide button.
@@ -31,8 +53,8 @@ namespace
 				}
 				else
 				{
-					printf_s("[XInput.NET] Failed to loaded xinput1_3.dll (error code 0x%08x, check that DirectX End-User Runtimes"
-						" is installed (http://www.microsoft.com/en-us/download/details.aspx?id=8109)\n", GetLastError());
+					printf_s("[XInput.NET] Failed to load xinput1_3.dll, xinput1_4.dll and xinput9_1_0.dll (error codes 0x%08x, 0x%08x, 0x%08x respectively; check that \"DirectX End-User Runtimes (June 2010)\""
+						" is installed (http://www.microsoft.com/en-us/download/details.aspx?id=8109)\n", xinput1_3_ErrorCode, xinput1_4_ErrorCode, xinput9_1_ErrorCode);
 				}
 			}
 		}


### PR DESCRIPTION
Self-explanatory! I've tested this on Win 7, Win 8 (with XInput 1.3 installed) and Win 8 (with only XInput 1.4 installed) and XInputReporter.exe now works correctly instead of crashing.

I've not tested Unity yet.

I also don't have any machines with just XInput 9.1.0 so can't test that, but from the docs it looks like it should always exist when XInput 1.4 is installed so I doubt that code will ever get called!

I also snuck in a fix for XInputDemo showing the state of the X button instead of the B button, which @gridgem added in his fork.