### PR TITLE
Protect against null pointer dereference in case GetProcAddress fails

### DIFF
--- a/XInputInterface/GamePad.cpp
+++ b/XInputInterface/GamePad.cpp
@@ -73,12 +73,22 @@ namespace
 DWORD XInputGamePadGetState(DWORD dwUserIndex, XINPUT_STATE* pState)
 {
 	gXInputLoader.ensureLoaded();
-	return gXInputLoader.mGetState(dwUserIndex, pState);
+	if(gXInputLoader.mGetState != NULL)
+	{
+		return gXInputLoader.mGetState(dwUserIndex, pState);
+	}
+	else
+	{
+		return ERROR_DEVICE_NOT_CONNECTED;
+	}
 }
 
 void XInputGamePadSetState(DWORD dwUserIndex, float leftMotor, float rightMotor)
 {
 	gXInputLoader.ensureLoaded();
-	XINPUT_VIBRATION vibration = { (int)(leftMotor * 65535), (int)(rightMotor * 65535) };
-	gXInputLoader.mSetState(dwUserIndex, &vibration);
+	if(gXInputLoader.mSetState != NULL)
+	{
+		XINPUT_VIBRATION vibration = { (int)(leftMotor * 65535), (int)(rightMotor * 65535) };
+		gXInputLoader.mSetState(dwUserIndex, &vibration);
+	}
 }


### PR DESCRIPTION
As pointed out by @dantreble, GetProcAddress can fail which will lead to a null pointer dereference. This will apparently happen when XInput 1.4 and 1.3 are not installed, but 9.1.0 is. Apparently that's possible :)

This PR just guards against the dereference itself and doesn't try to 'repair' the GetProcAddress failure, since there's not an obviously superior way to do that!