### PR TITLE
[Unity Example Code] Vibration fix

### DIFF
--- a/XInputUnity/Assets/XInputDotNet/Examples/XInputTestCS.cs
+++ b/XInputUnity/Assets/XInputDotNet/Examples/XInputTestCS.cs
@@ -14,6 +14,13 @@ public class XInputTestCS : MonoBehaviour
         // No need to initialize anything for the plugin
     }
 
+    void FixedUpdate()
+    {
+        // SetVibration should be sent in a slower rate.
+        // Set vibration according to triggers
+        GamePad.SetVibration(playerIndex, state.Triggers.Left, state.Triggers.Right);
+    }
+
     // Update is called once per frame
     void Update()
     {
@@ -40,16 +47,13 @@ public class XInputTestCS : MonoBehaviour
         // Detect if a button was pressed this frame
         if (prevState.Buttons.A == ButtonState.Released && state.Buttons.A == ButtonState.Pressed)
         {
-            renderer.material.color = new Color(Random.value, Random.value, Random.value, 1.0f);
+            GetComponent<Renderer>().material.color = new Color(Random.value, Random.value, Random.value, 1.0f);
         }
         // Detect if a button was released this frame
         if (prevState.Buttons.A == ButtonState.Pressed && state.Buttons.A == ButtonState.Released)
         {
-            renderer.material.color = new Color(1.0f, 1.0f, 1.0f, 1.0f);
+            GetComponent<Renderer>().material.color = new Color(1.0f, 1.0f, 1.0f, 1.0f);
         }
-
-        // Set vibration according to triggers
-        GamePad.SetVibration(playerIndex, state.Triggers.Left, state.Triggers.Right);
 
         // Make the current object turn
         transform.localRotation *= Quaternion.Euler(0.0f, state.ThumbSticks.Left.X * 25.0f * Time.deltaTime, 0.0f);


### PR DESCRIPTION
Higher framerate might make left vibrator unresponsive.
Prevent set state being sent too frequently by moving SetVibration() into FixedUpdate().

This is a fix for #22 

Also revised the obsoleted renderer field.
