### PR TITLE
Fix struct size for XInputGetStateEx

### DIFF
--- a/XInputDotNetPure/GamePad.cs
+++ b/XInputDotNetPure/GamePad.cs
@@ -211,6 +211,7 @@ namespace XInputDotNetPure
                 public short sThumbLY;
                 public short sThumbRX;
                 public short sThumbRY;
+                public uint dwPaddingReserved;
             }
         }
 


### PR DESCRIPTION
XInputGetStateEx is undocumented. It requires another four bytes of padding at the end of the XINPUT_STATE struct.

This can crash. See similar issues in the mumble-voip project:

https://github.com/mumble-voip/mumble/issues/2016
https://github.com/mumble-voip/mumble/issues/2018
https://github.com/mumble-voip/mumble/issues/2019

I'm not sure why this doesn't crash for your clients on Windows. I discovered this trying to get THOTH to work in Wine, where it crashed due to us writing to this missing field. Perhaps MS's .NET allocates memory differently from wine-mono, meaning the overrun doens't trigger a crash.

Anyway this PR should fix it going forward.